### PR TITLE
Support the language-ruby-on-rails package

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ class RubyLanguageClient extends AutoLanguageClient {
     this.busySignal = busySignal
   }
 
-  getGrammarScopes () { return ['source.rb', 'source.ruby'] }
+  getGrammarScopes () { return ['source.rb', 'source.ruby', 'source.ruby.rails', 'source.ruby.rails.rjs'] }
   getLanguageName () { return 'Ruby' }
   getServerName () { return 'Ruby-lang-server' }
   getConnectionType() { return 'stdio' } // ipc, socket, stdio


### PR DESCRIPTION
Atom's `language-ruby-on-rails` package adds grammars for "Ruby on Rails" and "Ruby on Rails (RJS)", amongst others.  This patch allows ide-ruby to process files that use those grammars as well.  (They're just Ruby, so it works out of the box.)